### PR TITLE
Add gl-native label scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,8 +96,11 @@ function getScore(issue) {
 
 const labelScores = {
     'release blocker': 25,
+    'beta blocker': 20,
     'high priority': 7,
     'medium priority': 5,
+    'crash': 5,
+    'build': 5,
     'bug': 2
 };
 


### PR DESCRIPTION
Added some priority-indicating mapbox/mapbox-gl-native labels that don’t have analogues in mapbox/mapbox-gl-js.

/cc @lucaswoj @tobrun